### PR TITLE
Increase the barrier timeout for the router job to 12h

### DIFF
--- a/daily-perf/cache/bench.jsonnet
+++ b/daily-perf/cache/bench.jsonnet
@@ -136,7 +136,7 @@ function(duration='300', threads='4', poolsize='43', concurrency='20', nkeys='10
                  },
                  steps: [
                      // Wait for the test to finish
-                     systemslab.barrier('test-finish'),
+                     systemslab.barrier('test-finish', timeout = 3600 * 12),
                  ],
             },
             # storage: {


### PR DESCRIPTION
The latest set of experiment failures were due to hitting the default 1h timeout on how long a barrier will wait. The fix here is to bump up the timeout on the relevant barrier, I have made it 12h now.

This shouldn't be an issue in the next release since I will be adding an overall job timeout which means that barriers will no longer have a timeout by default.