### PR TITLE
remove useless barrier

### DIFF
--- a/daily-perf/cache/bench.jsonnet
+++ b/daily-perf/cache/bench.jsonnet
@@ -109,9 +109,6 @@ function(duration='300', threads='4', poolsize='43', concurrency='20', nkeys='10
                     // Write out the toml config
                     systemslab.write_file('loadgen.toml', loadgen),
 
-                    // Wait for the backend and frontend dummy jobs to start
-                    systemslab.barrier('test-start'),
-
                     // Now run the real benchmark
                     systemslab.bash(|||
                         set -a && source /etc/environment && set +a


### PR DESCRIPTION
Remove the `test-start` barrier, as it serves no purpose in the current config and will complete immediately.